### PR TITLE
GDB-14318 Extends version announcement logic

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
@@ -18,11 +18,13 @@ import java.util.function.Consumer;
 
 import org.eclipse.rdf4j.common.io.Sink;
 import org.eclipse.rdf4j.common.lang.FileFormat;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.TripleTerm;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Statements;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
@@ -46,6 +48,15 @@ public abstract class AbstractRDFWriter implements RDFWriter, Sink {
 	private WriterConfig writerConfig = new WriterConfig();
 
 	private boolean writingStarted;
+	/**
+	 * True once at least one RDF 1.2-specific feature (triple term or directional literal) has been observed in the
+	 * incoming stream.
+	 */
+	private boolean rdf12FeatureDetected;
+	/**
+	 * True once the version announcement has been written to the output stream.
+	 */
+	private boolean versionAnnouncementWritten;
 
 	protected Consumer<Statement> statementConsumer;
 
@@ -140,6 +151,101 @@ public abstract class AbstractRDFWriter implements RDFWriter, Sink {
 		if (!writingStarted) {
 			throw new RDFHandlerException("Document writing has not started yet");
 		}
+	}
+
+	/**
+	 * Returns {@code true} if the given {@link Value} requires an RDF 1.2 version announcement (i.e. it is a triple
+	 * term or a directional language-tagged literal).
+	 *
+	 * @param v the value to test – may be {@code null}, in which case {@code false} is returned.
+	 */
+	public static boolean isRdf12Feature(Value v) {
+		if (v == null) {
+			return false;
+		}
+		return v.isTripleTerm()
+				|| (v.isLiteral() && RDF.DIRLANGSTRING.equals(((Literal) v).getDatatype()));
+	}
+
+	/**
+	 * Records that an RDF 1.2-specific feature was observed in {@code values}. Has no effect once the first feature has
+	 * already been noted.
+	 *
+	 * @param values zero or more {@link Value}s to inspect.
+	 */
+	protected void noteRdf12Feature(Value... values) {
+		if (!rdf12FeatureDetected) {
+			for (Value v : values) {
+				if (isRdf12Feature(v)) {
+					rdf12FeatureDetected = true;
+					return;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Returns {@code true} if at least one RDF 1.2-specific feature has been noted so far.
+	 */
+	protected boolean isRdf12FeatureDetected() {
+		return rdf12FeatureDetected;
+	}
+
+	/**
+	 * Returns {@code true} if the version announcement has already been written to the output stream.
+	 */
+	protected boolean isVersionAnnouncementWritten() {
+		return versionAnnouncementWritten;
+	}
+
+	/**
+	 * Override to return {@code true} for writers where an inline version announcement is mandatory when RDF
+	 * 1.2-specific features are serialised (Turtle, TriG, N3, N-Triples, N-Quads).
+	 * <p>
+	 * Returns {@code false} by default (JSON-LD, RDF/JSON, NDJSON-LD writers keep it optional).
+	 */
+	protected boolean requiresVersionAnnouncement() {
+		return false;
+	}
+
+	/**
+	 * Called by {@link #ensureVersionAnnouncement()} immediately before {@link #writeVersionAnnouncement()}. Override
+	 * to flush / close any open output structure that must not straddle the version directive (e.g. TurtleWriter closes
+	 * an open predicate-object list).
+	 * <p>
+	 * Default implementation is a no-op.
+	 */
+	protected void prepareForVersionAnnouncement() throws RDFHandlerException {
+		// no-op; subclasses may override
+	}
+
+	/**
+	 * Writes the format-specific version directive to the output stream. Called at most once per document, by
+	 * {@link #ensureVersionAnnouncement()}.
+	 * <p>
+	 * Default implementation is a no-op; concrete writers must override this.
+	 */
+	protected void writeVersionAnnouncement() throws RDFHandlerException {
+		// no-op; subclasses override
+	}
+
+	/**
+	 * Emits the version announcement if — and only if — all of the following hold:
+	 * <ul>
+	 * <li>at least one RDF 1.2 feature has been observed ({@link #noteRdf12Feature});</li>
+	 * <li>the announcement has not been written yet;</li>
+	 * <li>{@link #requiresVersionAnnouncement()} returns {@code true}.</li>
+	 * </ul>
+	 * Calls {@link #prepareForVersionAnnouncement()} before writing to let writers close any open output structure
+	 * first.
+	 */
+	protected final void ensureVersionAnnouncement() throws RDFHandlerException {
+		if (!rdf12FeatureDetected || versionAnnouncementWritten || !requiresVersionAnnouncement()) {
+			return;
+		}
+		prepareForVersionAnnouncement();
+		writeVersionAnnouncement();
+		versionAnnouncementWritten = true;
 	}
 
 	private void handleStatementConvertTripleTerms(Statement st) {

--- a/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriter.java
+++ b/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriter.java
@@ -42,6 +42,11 @@ public class NQuadsWriter extends NTriplesWriter {
 	@Override
 	public void consumeStatement(Statement st) throws RDFHandlerException {
 		try {
+			// Detect RDF 1.2 features and emit version announcement before
+			// the first affected quad is written.
+			noteRdf12Feature(st.getSubject(), st.getObject());
+			ensureVersionAnnouncement();
+
 			// SUBJECT
 			writeValue(st.getSubject());
 			writer.write(" ");

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
@@ -81,6 +81,25 @@ public class NTriplesWriter extends AbstractRDFWriter implements CharSink {
 	}
 
 	@Override
+	protected boolean requiresVersionAnnouncement() {
+		return true;
+	}
+
+	/**
+	 * Writes the N-Triples / N-Quads version directive as the very first output line once an RDF 1.2 feature is
+	 * detected. Per the RDF 1.2 N-Triples specification, this must appear before any triple that uses a
+	 * version-dependent feature.
+	 */
+	@Override
+	protected void writeVersionAnnouncement() throws RDFHandlerException {
+		try {
+			writer.write("VERSION \"1.2\"\n");
+		} catch (IOException e) {
+			throw new RDFHandlerException(e);
+		}
+	}
+
+	@Override
 	public void endRDF() throws RDFHandlerException {
 		checkWritingStarted();
 		try {
@@ -99,6 +118,11 @@ public class NTriplesWriter extends AbstractRDFWriter implements CharSink {
 	@Override
 	protected void consumeStatement(Statement st) {
 		try {
+			// Detect RDF 1.2 features and emit version announcement before
+			// the first affected triple is written (pure streaming — no buffering).
+			noteRdf12Feature(st.getSubject(), st.getObject());
+			ensureVersionAnnouncement();
+
 			writeValue(st.getSubject());
 			writer.write(" ");
 			writeIRI(st.getPredicate());

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGWriter.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGWriter.java
@@ -159,9 +159,13 @@ public class TriGWriter extends TurtleWriter {
 	}
 
 	@Override
-	protected void writeVersion() throws IOException {
-		closeActiveContext();
-		super.writeVersion();
+	protected void writeVersionAnnouncement() throws RDFHandlerException {
+		try {
+			closeActiveContext();
+		} catch (IOException e) {
+			throw new RDFHandlerException(e);
+		}
+		super.writeVersionAnnouncement();
 	}
 
 	protected void closeActiveContext() throws IOException {

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -101,8 +101,6 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 
 	private ModelFactory modelFactory = new LinkedHashModelFactory();
 
-	private boolean versionPrinted = false;
-
 	/**
 	 * Creates a new TurtleWriter that will write to the supplied OutputStream.
 	 *
@@ -305,19 +303,9 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 		IRI pred = st.getPredicate();
 		Value obj = st.getObject();
 
-		if (!versionPrinted) {
-			if (usesVersion12(obj)) {
-				try {
-					// If we're in the middle of writing a structure, close it first
-					if (!statementClosed || !stack.isEmpty()) {
-						closePreviousStatement();
-					}
-					writeVersion();
-				} catch (IOException e) {
-					throw new RDFHandlerException(e);
-				}
-			}
-		}
+		// ── RDF 1.2 version announcement (streaming path) ──────────────────────
+		noteRdf12Feature(subj, obj);
+		ensureVersionAnnouncement();
 
 		try {
 			if (inlineBNodes) {
@@ -483,10 +471,34 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 		writer.writeEOL();
 	}
 
-	protected void writeVersion() throws IOException {
-		writer.write("VERSION \"1.2\"");
-		writer.writeEOL();
-		versionPrinted = true;
+	@Override
+	protected boolean requiresVersionAnnouncement() {
+		return true;
+	}
+
+	/**
+	 * Closes any open predicate-object list or blank-node structure before the version directive is written. Called by
+	 * {@link #ensureVersionAnnouncement()}.
+	 */
+	@Override
+	protected void prepareForVersionAnnouncement() throws RDFHandlerException {
+		try {
+			if (!statementClosed || !stack.isEmpty()) {
+				closePreviousStatement();
+			}
+		} catch (IOException e) {
+			throw new RDFHandlerException(e);
+		}
+	}
+
+	@Override
+	protected void writeVersionAnnouncement() throws RDFHandlerException {
+		try {
+			writer.write("VERSION \"1.2\"");
+			writer.writeEOL();
+		} catch (IOException e) {
+			throw new RDFHandlerException(e);
+		}
 	}
 
 	protected void writePredicate(IRI predicate) throws IOException {
@@ -858,13 +870,24 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 			return;
 		}
 
-		if (!versionPrinted && bufferedStatements.objects().stream().anyMatch(o -> usesVersion12(o))) {
-			try {
-				writeVersion();
-			} catch (IOException e) {
-				throw new RDFHandlerException(e);
+		// ── RDF 1.2 version announcement (buffering path) ──────────────────────
+		// Scan all buffered subjects and objects because the flag may not have
+		// been set yet (statements were buffered, not streamed one-by-one).
+		for (Value obj : bufferedStatements.objects()) {
+			if (isRdf12Feature(obj)) {
+				noteRdf12Feature(obj);
+				break;
 			}
 		}
+		if (!isRdf12FeatureDetected()) {
+			for (Value subj : bufferedStatements.subjects()) {
+				if (isRdf12Feature(subj)) {
+					noteRdf12Feature(subj);
+					break;
+				}
+			}
+		}
+		ensureVersionAnnouncement();
 
 		if (this.getRDFFormat().supportsContexts()) { // to allow use in Turtle extensions such a TriG
 			// primary grouping per context.
@@ -965,10 +988,6 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 	 */
 	private boolean isBuffering() {
 		return inlineBNodes || prettyPrint;
-	}
-
-	private static boolean usesVersion12(Value v) {
-		return v.isTripleTerm() || (v.isLiteral() && ((Literal) v).getDatatype() == RDF.DIRLANGSTRING);
 	}
 
 }


### PR DESCRIPTION
Extends the version announcement logic so it is applied in NTriples and Nquads writers. Fixes an issue with incorrect closing of context when statement is part of named graph and version has to be announced afterward for trig files. Fixes an issue with announcing version in the middle of ttl file where it concatenates the version to the previous triple.