### PR TITLE
GDB-14574 Updated name of settings for rdf12 version announcement

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
@@ -241,7 +241,7 @@ public abstract class AbstractRDFWriter implements RDFWriter, Sink {
 	 */
 	protected final void ensureVersionAnnouncement() throws RDFHandlerException {
 		if (!rdf12FeatureDetected || versionAnnouncementWritten || !requiresVersionAnnouncement()
-				|| !writerConfig.get(BasicWriterSettings.INCLUDE_RDF_VERSION)) {
+				|| !writerConfig.get(BasicWriterSettings.ANNOUNCE_RDF12_VERSION)) {
 			return;
 		}
 		prepareForVersionAnnouncement();

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -120,10 +120,10 @@ public class BasicWriterSettings {
 	 * <p>
 	 * Defaults to true.
 	 * <p>
-	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.include_rdf_version}.
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.announce_rdf12_version}.
 	 */
-	public static final BooleanRioSetting INCLUDE_RDF_VERSION = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.include_rdf_version",
+	public static final BooleanRioSetting ANNOUNCE_RDF12_VERSION = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.announce_rdf12_version",
 			"Include the rdf version declaration if RDF 1.2 features exist.", Boolean.TRUE);
 
 	/**

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/CanonicalizationTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/CanonicalizationTest.java
@@ -14,17 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.helpers.*;
 import org.eclipse.rdf4j.rio.languages.RFC3066LanguageHandler;
@@ -120,7 +115,7 @@ public class CanonicalizationTest extends TestCase {
 		// representation of the statements.
 		StringWriter stringWriter = new StringWriter();
 		RDFWriter writer = Rio.createWriter(format, stringWriter);
-		writer.getWriterConfig().set(BasicWriterSettings.INCLUDE_RDF_VERSION, false);
+		writer.getWriterConfig().set(BasicWriterSettings.ANNOUNCE_RDF12_VERSION, false);
 
 		Rio.write(inputCollection, writer);
 


### PR DESCRIPTION
Briefly describe the changes proposed in this PR:

Renaming of setting to BasicWriterSettings.ANNOUNCE_RDF12_VERSION for more clarity on the setting's purpose. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

